### PR TITLE
Refine cursor function typing

### DIFF
--- a/personal_graph/database/db.py
+++ b/personal_graph/database/db.py
@@ -1,11 +1,12 @@
 from abc import ABC, abstractmethod
+import sqlite3
 from typing import Any, Callable, Dict, Optional, List, Union
 from graphviz import Digraph  # type: ignore
 
 from personal_graph.models import Node, Edge
 
 # CursorExecFunction = Callable[[libsql.Cursor, libsql.Connection], Any]
-CursorExecFunction = Callable[[Any, Any], Any]  # TODO: Constraint the type
+CursorExecFunction = Callable[[sqlite3.Cursor, sqlite3.Connection], Any]
 
 
 class DB(ABC):

--- a/personal_graph/database/sqlite/sqlite.py
+++ b/personal_graph/database/sqlite/sqlite.py
@@ -10,9 +10,7 @@ from personal_graph.models import Node, Edge
 from jinja2 import BaseLoader, Environment, select_autoescape
 
 from personal_graph.visualizers import _as_dot_node, _as_dot_label
-from personal_graph.database.db import DB
-
-CursorExecFunction = Callable[[sqlite3.Cursor, sqlite3.Connection], Any]
+from personal_graph.database.db import DB, CursorExecFunction
 
 
 @lru_cache(maxsize=None)
@@ -606,7 +604,7 @@ class SQLite(DB):
         for i in ids:
             if i not in visited:
                 node = self.search_node(i)  # type: ignore
-                if node is []:
+                if node == []:
                     continue
 
                 name, label = _as_dot_node(

--- a/stub/personal_graph/database/sqlite/sqlite.pyi
+++ b/stub/personal_graph/database/sqlite/sqlite.pyi
@@ -1,12 +1,9 @@
 from graphviz import Digraph  # type: ignore
 from jinja2 import BaseLoader, Environment, Template
 from pathlib import Path
-import sqlean as sqlite3  # type: ignore
 from personal_graph.models import Edge as Edge, Node as Node
-from personal_graph.database.db import DB as DB
+from personal_graph.database.db import DB as DB, CursorExecFunction
 from typing import Any, Callable, Dict, List, Tuple, Optional
-
-CursorExecFunction = Callable[[sqlite3.Cursor, sqlite3.Connection], Any]
 
 def read_sql(sql_file: Path) -> str: ...
 


### PR DESCRIPTION
## Summary
- narrow `CursorExecFunction` to use `sqlite3.Cursor` and `sqlite3.Connection`
- import this alias in SQLite database implementation
- update accompanying type stub

## Testing
- `ruff format personal_graph/database/db.py personal_graph/database/sqlite/sqlite.py stub/personal_graph/database/sqlite/sqlite.pyi`
- `ruff check personal_graph/database/db.py personal_graph/database/sqlite/sqlite.py stub/personal_graph/database/sqlite/sqlite.pyi`
- `poetry run python -m mypy .` *(fails: No module named mypy)*